### PR TITLE
Update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,7 +6,6 @@ coverage
 examples
 prof
 node_modules
-es
 test
 txt
 .coverals.yml


### PR DESCRIPTION
Avoid ignoring the es directory when publishing with npm, because it contains typescript type definitions, which will cause type definitions to be found after installation using yarn

ref: https://github.com/YuriGor/deepdash/issues/74