### PR TITLE
Fix return type of findDeep, Add missing field to IDeepEntry

### DIFF
--- a/src/IDeepEntry.d.ts
+++ b/src/IDeepEntry.d.ts
@@ -1,10 +1,16 @@
-import { Path } from './Path';
+import { Path } from "./Path";
+import { IIterateeContext } from "./IIterateeContext";
 
 export interface IDeepEntry {
   value: any;
   key?: string | number;
   path?: Path;
+  /**
+   * NOTE: At now, parent is not type of IDeepEntry. It is just parent.value
+   * JS source code should be fixed
+   */
   parent?: IDeepEntry;
+  context?: IIterateeContext;
   /**
    * contains matched childrenPath path of this parent node, chosen from childrenPath array, if it was specified.
    */

--- a/src/findDeep.d.ts
+++ b/src/findDeep.d.ts
@@ -18,5 +18,4 @@ export default function findDeep(
     leavesOnly?: boolean; // = false;
     rootIsChildren?: boolean;
   }
-): IDeepEntry;
-
+): IDeepEntry | undefined;


### PR DESCRIPTION
I fixed return type of findDeep and add context field to IDeepEntry interface.

But, for now, the type of parent field of IDeepEntry is not IDeepEntry. It is just same with parent.value.
It should be fix from the js source code, but I can't find where to fix it.

So I just add comment. 