### PR TITLE
fix: remove [] in Path

### DIFF
--- a/es/eachDeep.d.ts
+++ b/es/eachDeep.d.ts
@@ -12,7 +12,7 @@ export default function eachDeep(
   options?: {
     pathFormat?: "string" | "array"; // = "string";
     checkCircular?: boolean; // = false;
-    childrenPath?: Path[];
+    childrenPath?: Path;
     includeRoot?: boolean;
     leavesOnly?: boolean; // = false;
     rootIsChildren?: boolean;

--- a/es/filterDeep.d.ts
+++ b/es/filterDeep.d.ts
@@ -20,7 +20,7 @@ export default function filterDeep(
     pathFormat?: "string" | "array"; // = "string";
     checkCircular?: boolean; // = false;
     keepCircular?: boolean; // = false;
-    childrenPath?: Path[];
+    childrenPath?: Path;
     includeRoot?: boolean;
     leavesOnly?: boolean; // = false;
     rootIsChildren?: boolean;

--- a/es/findDeep.d.ts
+++ b/es/findDeep.d.ts
@@ -13,7 +13,7 @@ export default function findDeep(
   options?: {
     pathFormat?: "string" | "array"; // = "string";
     checkCircular?: boolean; // = false;
-    childrenPath?: Path[];
+    childrenPath?: Path;
     includeRoot?: boolean;
     leavesOnly?: boolean; // = false;
     rootIsChildren?: boolean;

--- a/es/findPathDeep.d.ts
+++ b/es/findPathDeep.d.ts
@@ -12,7 +12,7 @@ export default function findDeep(
   options?: {
     pathFormat?: "string" | "array"; // = "string";
     checkCircular?: boolean; // = false;
-    childrenPath?: Path[];
+    childrenPath?: Path;
     includeRoot?: boolean;
     leavesOnly?: boolean; // = false;
     rootIsChildren?: boolean;

--- a/es/findValueDeep.d.ts
+++ b/es/findValueDeep.d.ts
@@ -12,7 +12,7 @@ export default function findDeep(
   options?: {
     pathFormat?: "string" | "array"; // = "string";
     checkCircular?: boolean; // = false;
-    childrenPath?: Path[];
+    childrenPath?: Path;
     includeRoot?: boolean;
     leavesOnly?: boolean; // = false;
     rootIsChildren?: boolean;

--- a/es/index.d.ts
+++ b/es/index.d.ts
@@ -5,7 +5,7 @@ export default function index(
   options?: {
     checkCircular?: boolean;
     includeRoot?: boolean;
-    childrenPath?: Path[];
+    childrenPath?: Path;
     rootIsChildren?: boolean;
     leavesOnly?: boolean;
   }

--- a/es/mapDeep.d.ts
+++ b/es/mapDeep.d.ts
@@ -12,7 +12,7 @@ export default function mapDeep(
   options?: {
     pathFormat?: "string" | "array";
     checkCircular?: boolean;
-    childrenPath?: Path[];
+    childrenPath?: Path;
     includeRoot?: boolean;
     leavesOnly?: boolean;
     rootIsChildren?: boolean;

--- a/es/mapKeysDeep.d.ts
+++ b/es/mapKeysDeep.d.ts
@@ -12,7 +12,7 @@ export default function mapKeysDeep(
   options?: {
     pathFormat?: "string" | "array";
     checkCircular?: boolean;
-    childrenPath?: Path[];
+    childrenPath?: Path;
     includeRoot?: boolean;
     leavesOnly?: boolean;
     rootIsChildren?: boolean;

--- a/es/mapValuesDeep.d.ts
+++ b/es/mapValuesDeep.d.ts
@@ -12,7 +12,7 @@ export default function mapValuesDeep(
   options?: {
     pathFormat?: "string" | "array";
     checkCircular?: boolean;
-    childrenPath?: Path[];
+    childrenPath?: Path;
     includeRoot?: boolean;
     leavesOnly?: boolean;
     rootIsChildren?: boolean;

--- a/es/paths.d.ts
+++ b/es/paths.d.ts
@@ -6,9 +6,9 @@ export default function paths(
     pathFormat?: "string" | "array"; // = "string";
     checkCircular?: boolean; // = false;
     includeCircularPath?: boolean,
-    childrenPath?: Path[];
+    childrenPath?: Path;
     includeRoot?: boolean;
     leavesOnly?: boolean; // = false;
     rootIsChildren?: boolean;
   }
-): Path[];
+): Path;

--- a/es/reduceDeep.d.ts
+++ b/es/reduceDeep.d.ts
@@ -14,7 +14,7 @@ export default function reduceDeep(
   options?: {
     pathFormat?: "string" | "array";
     checkCircular?: boolean;
-    childrenPath?: Path[];
+    childrenPath?: Path;
     includeRoot?: boolean;
     leavesOnly?: boolean;
     rootIsChildren?: boolean;

--- a/es/someDeep.d.ts
+++ b/es/someDeep.d.ts
@@ -12,7 +12,7 @@ export default function someDeep(
   options?: {
     pathFormat?: "string" | "array"; // = "string";
     checkCircular?: boolean; // = false;
-    childrenPath?: Path[];
+    childrenPath?: Path;
     includeRoot?: boolean;
     leavesOnly?: boolean; // = false;
     rootIsChildren?: boolean;

--- a/src/eachDeep.d.ts
+++ b/src/eachDeep.d.ts
@@ -12,7 +12,7 @@ export default function eachDeep(
   options?: {
     pathFormat?: "string" | "array"; // = "string";
     checkCircular?: boolean; // = false;
-    childrenPath?: Path[];
+    childrenPath?: Path;
     includeRoot?: boolean;
     leavesOnly?: boolean; // = false;
     rootIsChildren?: boolean;

--- a/src/filterDeep.d.ts
+++ b/src/filterDeep.d.ts
@@ -20,7 +20,7 @@ export default function filterDeep(
     pathFormat?: "string" | "array"; // = "string";
     checkCircular?: boolean; // = false;
     keepCircular?: boolean; // = false;
-    childrenPath?: Path[];
+    childrenPath?: Path;
     includeRoot?: boolean;
     leavesOnly?: boolean; // = false;
     rootIsChildren?: boolean;

--- a/src/findDeep.d.ts
+++ b/src/findDeep.d.ts
@@ -13,7 +13,7 @@ export default function findDeep(
   options?: {
     pathFormat?: "string" | "array"; // = "string";
     checkCircular?: boolean; // = false;
-    childrenPath?: Path[];
+    childrenPath?: Path;
     includeRoot?: boolean;
     leavesOnly?: boolean; // = false;
     rootIsChildren?: boolean;

--- a/src/findPathDeep.d.ts
+++ b/src/findPathDeep.d.ts
@@ -12,7 +12,7 @@ export default function findDeep(
   options?: {
     pathFormat?: "string" | "array"; // = "string";
     checkCircular?: boolean; // = false;
-    childrenPath?: Path[];
+    childrenPath?: Path;
     includeRoot?: boolean;
     leavesOnly?: boolean; // = false;
     rootIsChildren?: boolean;

--- a/src/findValueDeep.d.ts
+++ b/src/findValueDeep.d.ts
@@ -12,7 +12,7 @@ export default function findDeep(
   options?: {
     pathFormat?: "string" | "array"; // = "string";
     checkCircular?: boolean; // = false;
-    childrenPath?: Path[];
+    childrenPath?: Path;
     includeRoot?: boolean;
     leavesOnly?: boolean; // = false;
     rootIsChildren?: boolean;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,7 +5,7 @@ export default function index(
   options?: {
     checkCircular?: boolean;
     includeRoot?: boolean;
-    childrenPath?: Path[];
+    childrenPath?: Path;
     rootIsChildren?: boolean;
     leavesOnly?: boolean;
   }

--- a/src/mapDeep.d.ts
+++ b/src/mapDeep.d.ts
@@ -12,7 +12,7 @@ export default function mapDeep(
   options?: {
     pathFormat?: "string" | "array";
     checkCircular?: boolean;
-    childrenPath?: Path[];
+    childrenPath?: Path;
     includeRoot?: boolean;
     leavesOnly?: boolean;
     rootIsChildren?: boolean;

--- a/src/mapKeysDeep.d.ts
+++ b/src/mapKeysDeep.d.ts
@@ -12,7 +12,7 @@ export default function mapKeysDeep(
   options?: {
     pathFormat?: "string" | "array";
     checkCircular?: boolean;
-    childrenPath?: Path[];
+    childrenPath?: Path;
     includeRoot?: boolean;
     leavesOnly?: boolean;
     rootIsChildren?: boolean;

--- a/src/mapValuesDeep.d.ts
+++ b/src/mapValuesDeep.d.ts
@@ -12,7 +12,7 @@ export default function mapValuesDeep(
   options?: {
     pathFormat?: "string" | "array";
     checkCircular?: boolean;
-    childrenPath?: Path[];
+    childrenPath?: Path;
     includeRoot?: boolean;
     leavesOnly?: boolean;
     rootIsChildren?: boolean;

--- a/src/paths.d.ts
+++ b/src/paths.d.ts
@@ -6,9 +6,9 @@ export default function paths(
     pathFormat?: "string" | "array"; // = "string";
     checkCircular?: boolean; // = false;
     includeCircularPath?: boolean,
-    childrenPath?: Path[];
+    childrenPath?: Path;
     includeRoot?: boolean;
     leavesOnly?: boolean; // = false;
     rootIsChildren?: boolean;
   }
-): Path[];
+): Path;

--- a/src/reduceDeep.d.ts
+++ b/src/reduceDeep.d.ts
@@ -14,7 +14,7 @@ export default function reduceDeep(
   options?: {
     pathFormat?: "string" | "array";
     checkCircular?: boolean;
-    childrenPath?: Path[];
+    childrenPath?: Path;
     includeRoot?: boolean;
     leavesOnly?: boolean;
     rootIsChildren?: boolean;

--- a/src/someDeep.d.ts
+++ b/src/someDeep.d.ts
@@ -12,7 +12,7 @@ export default function someDeep(
   options?: {
     pathFormat?: "string" | "array"; // = "string";
     checkCircular?: boolean; // = false;
-    childrenPath?: Path[];
+    childrenPath?: Path;
     includeRoot?: boolean;
     leavesOnly?: boolean; // = false;
     rootIsChildren?: boolean;


### PR DESCRIPTION
This PR fixes type mismatch when using with TypeScript. Type Path already contains an Array<string | number>, so there is no need to add square brackets when annotate Path.

Also in documentation, for example, childrenPath is specified as string, which is impossible with current types.